### PR TITLE
Add initial support for LinearAlgebra.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "fb0a3009-a0ba-48c7-b828-2efdeaae8962"
 authors = ["John Omotani <john.omotani@ukaea.uk>"]
 version = "0.1.0"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [weakdeps]
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -176,4 +176,6 @@ end
     return InboundsArray(view(a.a, I...))
 end
 
+include("LinearAlgebra_support.jl")
+
 end # module InboundsArrays

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -41,7 +41,7 @@ InboundsVector{T, TVector} = InboundsArray{T, 1, TVector} where {T, TVector}
 InboundsMatrix{T, TMatrix} = InboundsArray{T, 2, TMatrix} where {T, TMatrix}
 
 import Base: getindex, setindex!, size, IndexStyle, length, similar, axes, BroadcastStyle,
-             copyto!, resize!, unsafe_convert, strides, elsize, view, maybeview
+             copyto!, copy, resize!, unsafe_convert, strides, elsize, view, maybeview
 
 InboundsArray(A::InboundsArray) = A
 

--- a/src/LinearAlgebra_support.jl
+++ b/src/LinearAlgebra_support.jl
@@ -1,0 +1,48 @@
+# Functions from LinearAlgebra.jl need to hand the work back to the optimized
+# implementations that work on `Array`, instead of the generic ones for `AbstractArray`.
+
+import LinearAlgebra: lu, lu!, ldiv!, ldiv, Factorization, mul!
+
+@inline function ldiv!(x::InboundsVector, Alu::Factorization, b::InboundsVector)
+    ldiv!(x.a, Alu, b.a)
+    return x
+end
+@inline function ldiv!(x::InboundsMatrix, Alu::Factorization, b::InboundsMatrix)
+    ldiv!(x.a, Alu, b.a)
+    return x
+end
+
+@inline function ldiv!(Alu::Factorization, b::InboundsVector)
+    ldiv!(Alu, b.a)
+    return b
+end
+@inline function ldiv!(Alu::Factorization, b::InboundsMatrix)
+    ldiv!(Alu, b.a)
+    return b
+end
+
+@inline function ldiv(Alu::Factorization, b::InboundsVector)
+    return InboundsArray(ldiv(Alu, b.a))
+end
+@inline function ldiv(Alu::Factorization, b::InboundsMatrix)
+    return InboundsArray(ldiv(Alu, b.a))
+end
+
+@inline function lu(m::InboundsMatrix)
+    return lu(m.a)
+end
+
+@inline function lu!(m::InboundsMatrix)
+    return lu(m.a)
+end
+
+# Need to use specific enough types for `mul!()` arguments that these versions take
+# precedence over AbstractVector versions defined in LinearAlgebra.
+@inline function mul!(C::InboundsMatrix, A::InboundsMatrix, B::InboundsMatrix, α::Number, β::Number)
+    mul!(C.a, A.a, B.a, α, β)
+    return C
+end
+@inline function mul!(C::InboundsVector, A::InboundsMatrix, B::InboundsVector, α::Number, β::Number)
+    mul!(C.a, A.a, B.a, α, β)
+    return C
+end


### PR DESCRIPTION
Various functions in `LinearAlgebra` need wrapping to pass the `Array` wrapped by an `InboundsArray` through to the specialised implementation, rather than a much slower, generic `AbstractArray` implementation. This PR starts to add support for a few functions - `mul!()`, `lu()`, `lu!()` and `ldiv!()` - but others will probably need to be added when people need them.