### PR TITLE
`get_noninbounds()` to extract wrapped array from `InboundsArray`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Broadcasting is implemented so that the result of broadcasting an InboundsArray 
 other array types is an InboundsArray (if the result is an array and not a scalar). So `c`
 in the example above is an `InboundsArray`.
 
+To get the wrapped, non-inbounds array back from an `InboundsArray` use
+```julia
+a_noninbounds = get_noninbounds(a)
+```
+`get_noninbouds()` is a no-op on anything other than an `InboundsArray`.
+
 
 Testing - this is very IMPORTANT!
 ---------------------------------
@@ -25,6 +31,7 @@ Testing - this is very IMPORTANT!
 As bounds checks (on array accesses) are disabled by default when using `InboundsArray`,
 you should make sure to test your package using `--check-bounds=yes`, which will restore
 the bounds checks.
+
 
 Status and development
 ----------------------

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -30,7 +30,8 @@ the bounds checks.
 module InboundsArrays
 
 export InboundsArray, InboundsVector, InboundsMatrix, AbstractInboundsArray,
-       InboundsSparseMatrixCSC, InboundsSparseVector, InboundsSparseMatrixCSR
+       InboundsSparseMatrixCSC, InboundsSparseVector, InboundsSparseMatrixCSR,
+       get_noninbounds
 
 abstract type AbstractInboundsArray{T, N} <: AbstractArray{T, N} end
 
@@ -77,6 +78,16 @@ end
 function InboundsMatrix{T, TMatrix}(arg1, arg2, arg3) where {T, TMatrix}
     return InboundsMatrix(TMatrix(arg1, arg2, arg3))
 end
+
+"""
+    get_noninbounds(A)
+
+If `A` is an `InboundsArray{T, N, TArray}`, returns the wrapped array of type `TArray`,
+otherwise returns `A` unchanged.
+"""
+function get_noninbounds end
+@inline get_noninbounds(A::AbstractInboundsArray) = A.a
+@inline get_noninbounds(A) = A
 
 @inline function getindex(A::AbstractInboundsArray, args...)
     return @inbounds getindex(A.a, args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,9 @@ function runtests()
             @test size(d) == (3, 5)
 
             @test axes(a) == (1:4,)
+
+            @test !isa(get_noninbounds(a), AbstractInboundsArray)
+            @test !isa(get_noninbounds(zeros(3)), AbstractInboundsArray)
         end
 
         @testset "InboundsMatrix" begin
@@ -117,6 +120,9 @@ function runtests()
             @test size(d) == (3, 5, 6)
 
             @test axes(a) == (1:2, 1:2)
+
+            @test !isa(get_noninbounds(a), AbstractInboundsArray)
+            @test !isa(get_noninbounds(zeros(3, 3)), AbstractInboundsArray)
         end
 
         @testset "InboundsArray" begin
@@ -173,6 +179,9 @@ function runtests()
             @test size(d) == (3, 5)
 
             @test axes(a) == (1:2, 1:2, 1:2)
+
+            @test !isa(get_noninbounds(a), AbstractInboundsArray)
+            @test !isa(get_noninbounds(zeros(3, 3, 3)), AbstractInboundsArray)
         end
 
         @testset "LinearAlgebra interface" begin


### PR DESCRIPTION
To get the wrapped, non-inbounds array back from an `InboundsArray`, can now use
```julia
a_noninbounds = get_noninbounds(a)
```
`get_noninbouds()` is a no-op on anything other than an `InboundsArray`.