### PR TITLE
Make AbstractInboundsArray not an AbstractArray by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,17 +13,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        abstractarray: [false, true]
+        julia_version: ['1.10', '1']
       fail-fast: false
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
+        with:
+          version: '${{ matrix.julia_version }}'
       - uses: julia-actions/cache@v2
       - run: |
           julia --project -e 'import Pkg; Pkg.add(["FFTW", "MPI"])'
         shell: bash
       - uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia --project -e 'using InboundsArrays; InboundsArrays.set_inherit_from_AbstractArray(true)'
+        if: matrix.abstractarray
+        shell: bash
       - uses: julia-actions/julia-runtest@v1
 
   test-check-bounds-auto:
@@ -31,17 +39,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        abstractarray: [false, true]
+        julia_version: ['1.10', '1']
       fail-fast: false
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
+        with:
+          version: '${{ matrix.julia_version }}'
       - uses: julia-actions/cache@v2
       - run: |
           julia --project -e 'import Pkg; Pkg.add(["FFTW", "MPI"])'
         shell: bash
       - uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia --project -e 'using InboundsArrays; InboundsArrays.set_inherit_from_AbstractArray(true)'
+        if: matrix.abstractarray
+        shell: bash
       # The following is copied and simplified from
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           version: '${{ matrix.julia_version }}'
       - uses: julia-actions/cache@v2
       - run: |
-          julia --project -e 'import Pkg; Pkg.add(["FFTW", "MPI"])'
+          julia --project -e 'import Pkg; Pkg.add(["FFTW", "HDF5", "MPI"])'
         shell: bash
       - uses: julia-actions/julia-buildpkg@v1
       - run: |
@@ -51,7 +51,7 @@ jobs:
           version: '${{ matrix.julia_version }}'
       - uses: julia-actions/cache@v2
       - run: |
-          julia --project -e 'import Pkg; Pkg.add(["FFTW", "MPI"])'
+          julia --project -e 'import Pkg; Pkg.add(["FFTW", "HDF5", "MPI"])'
         shell: bash
       - uses: julia-actions/julia-buildpkg@v1
       - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InboundsArrays"
 uuid = "fb0a3009-a0ba-48c7-b828-2efdeaae8962"
 authors = ["John Omotani <john.omotani@ukaea.uk>"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,12 @@ SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 
 [weakdeps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 
 [extensions]
 FFTWExt = "FFTW"
+HDF5Ext = "HDF5"
 MPIExt = "MPI"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ At present, `InboundsArray` supports:
     * Broadcasting
     * `reshape()` and `vec()`
     * `reverse!()`, `reverse()`, `push!()`, `pop!()`
+    * `sum()`, `prod()`, `maximum()`, `minimum()`, `extrema()`, `all()`, `any()`
     * If inheriting from `AbstractArray` is enabled:
         * The `AbstractArray` interface and broadcasting (returning an `InboundsArray`)
         * Also any package that only requires the generic `AbstractArray` interface

--- a/README.md
+++ b/README.md
@@ -130,5 +130,5 @@ At present, `InboundsArray` supports:
   not been comprehensively tested
     * `Buffer`, `UBuffer`, `VBuffer`
 * `FFTW`
-    * `plan_fft!`, `plan_ifft!`, `*`
+    * `plan_fft!`, `plan_ifft!`, `plan_r2r!`, `*`
 * `HDF5` is intended to support all functionality

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Coverage
 
 At present, `InboundsArray` supports:
 * `Base` functionality
-    * `getindex()`, `setindex!()`, `length()`, `size()`, `axes()`, `similar()`.
+    * `getindex()`, `setindex!()`, `length()`, `size()`, `ndims()`, `axes()`, `similar()`.
     * Broadcasting
     * `reshape()` and `vec()`
     * `reverse!()`, `reverse()`, `push!()`, `pop!()`

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ At present, `InboundsArray` supports:
     * `getindex()`, `setindex!()`, `length()`, `size()`, `axes()`, `similar()`.
     * Broadcasting
     * `reshape()` and `vec()`
+    * `reverse!()`, `reverse()`, `push!()`, `pop!()`
     * If inheriting from `AbstractArray` is enabled:
         * The `AbstractArray` interface and broadcasting (returning an `InboundsArray`)
         * Also any package that only requires the generic `AbstractArray` interface

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ At present, `InboundsArray` supports:
     * `reshape()` and `vec()`
     * `reverse!()`, `reverse()`, `push!()`, `pop!()`
     * `sum()`, `prod()`, `maximum()`, `minimum()`, `extrema()`, `all()`, `any()`
+    * `adjoint()`, `transpose()`, `inv()`
     * `searchsorted()`, `searchsortedfirst()`, `searchsortedlast()`,
       `findfirst()`, `findlast()`, `findnext()`, `findprev()`, `findall()`,
       `findmax()`, `findmin()`, `findmax!()`, `findmin!()`

--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ At present, `InboundsArray` supports:
     * `Buffer`, `UBuffer`, `VBuffer`
 * `FFTW`
     * `plan_fft!`, `plan_ifft!`, `*`
+* `HDF5` is intended to support all functionality

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ At present, `InboundsArray` supports:
 * `Base` functionality
     * `getindex()`, `setindex!()`, `length()`, `size()`, `ndims()`, `axes()`, `similar()`.
     * Broadcasting
-    * `reshape()` and `vec()`
+    * `reshape()`, `vec()`, `selectdim()`
     * `reverse!()`, `reverse()`, `push!()`, `pop!()`
     * `sum()`, `prod()`, `maximum()`, `minimum()`, `extrema()`, `all()`, `any()`
     * `adjoint()`, `transpose()`, `inv()`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ At present, `InboundsArray` supports:
     * `reshape()` and `vec()`
     * `reverse!()`, `reverse()`, `push!()`, `pop!()`
     * `sum()`, `prod()`, `maximum()`, `minimum()`, `extrema()`, `all()`, `any()`
+    * `searchsorted()`, `searchsortedfirst()`, `searchsortedlast()`,
+      `findfirst()`, `findlast()`, `findnext()`, `findprev()`, `findall()`,
+      `findmax()`, `findmin()`, `findmax!()`, `findmin!()`
     * If inheriting from `AbstractArray` is enabled:
         * The `AbstractArray` interface and broadcasting (returning an `InboundsArray`)
         * Also any package that only requires the generic `AbstractArray` interface

--- a/ext/FFTWExt.jl
+++ b/ext/FFTWExt.jl
@@ -3,7 +3,7 @@ module FFTWExt
 using InboundsArrays
 
 import FFTW
-import FFTW: plan_fft!, plan_ifft!
+import FFTW: plan_fft!, plan_ifft!, plan_r2r!
 import Base: *
 
 @inline function plan_fft!(a::AbstractInboundsArray, args...; kwargs...)
@@ -12,6 +12,10 @@ end
 
 @inline function plan_ifft!(a::AbstractInboundsArray, args...; kwargs...)
     return plan_ifft!(a.a, args...; kwargs...)
+end
+
+@inline function plan_r2r!(a::AbstractInboundsArray, args...; kwargs...)
+    return plan_r2r!(a.a, args...; kwargs...)
 end
 
 @inline function *(p::FFTW.FFTWPlan, a::InboundsArray)

--- a/ext/HDF5Ext.jl
+++ b/ext/HDF5Ext.jl
@@ -1,0 +1,16 @@
+module HDF5Ext
+
+using InboundsArrays
+
+import HDF5
+import Base: setindex!
+
+@inline function setindex!(dset::HDF5.Dataset, x::AbstractInboundsArray, I::HDF5.IndexType...)
+    return @inbounds setindex!(dset, x.a, I...)
+end
+
+@inline function setindex!(dset::HDF5.File, x::AbstractInboundsArray, path::String)
+    return @inbounds setindex!(dset, x.a, path)
+end
+
+end # module HDF5Ext

--- a/ext/MPIExt.jl
+++ b/ext/MPIExt.jl
@@ -5,6 +5,8 @@ using InboundsArrays
 import MPI
 import MPI: Buffer, UBuffer, VBuffer
 
+const inherit_from_AbstractArray = InboundsArrays.inherit_from_AbstractArray
+
 @inline function Buffer(a::AbstractInboundsArray)
     return Buffer(a.a)
 end
@@ -15,6 +17,79 @@ end
 
 @inline function VBuffer(arr::InboundsArray, counts::Vector{Cint}, displs::Vector{Cint}, dtype::MPI.Datatype)
     return VBuffer(arr.a, counts, displs, dtype)
+end
+
+if !inherit_from_AbstractArray
+    @inline function UBuffer(data::AbstractInboundsArray, args...)
+        return UBuffer(data.a, args...)
+    end
+    @inline function VBuffer(data::AbstractInboundsArray, args...)
+        return VBuffer(data.a, args...)
+    end
+
+    using MPI: Comm, Win
+    import MPI: Scatter!, Gather!, Allgather!, Allgather, Reduce, Allreduce, Scan, Exscan,
+           Neighbor_allgather!, Neighbor_allgatherv!, Win_attach!, Send
+
+    Scatter!(sendbuf::AbstractInboundsArray{T}, recvbuf::Union{Ref{T},AbstractInboundsArray{T}}, root::Integer, comm::Comm) where {T} =
+        Scatter!(UBuffer(sendbuf,length(recvbuf)), recvbuf, root, comm)
+    Scatter!(sendbuf::AbstractArray{T}, recvbuf::Union{Ref{T},AbstractInboundsArray{T}}, root::Integer, comm::Comm) where {T} =
+        Scatter!(UBuffer(sendbuf,length(recvbuf)), recvbuf, root, comm)
+    Scatter!(sendbuf::AbstractInboundsArray{T}, recvbuf::Union{AbstractArray{T}}, root::Integer, comm::Comm) where {T} =
+        Scatter!(UBuffer(sendbuf,length(recvbuf)), recvbuf, root, comm)
+    Gather!(sendbuf::Union{Ref,AbstractInboundsArray}, recvbuf::AbstractInboundsArray, root::Integer, comm::Comm) =
+        Gather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), root, comm)
+    Gather!(sendbuf::Union{Ref,AbstractInboundsArray}, recvbuf::AbstractArray, root::Integer, comm::Comm) =
+        Gather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), root, comm)
+    Gather!(sendbuf::Union{Ref,AbstractArray}, recvbuf::AbstractInboundsArray, root::Integer, comm::Comm) =
+        Gather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), root, comm)
+    Gather(sendbuf::AbstractInboundsArray, root::Integer, comm::Comm) =
+        Gather!(sendbuf, Comm_rank(comm) == root ? similar(sendbuf, Comm_size(comm) * length(sendbuf)) : nothing, root, comm)
+    Allgather!(sendbuf::Union{Ref,AbstractInboundsArray}, recvbuf::AbstractInboundsArray, comm::Comm) =
+        Allgather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), comm)
+    Allgather!(sendbuf::AbstractInboundsArray, recvbuf::AbstractArray, comm::Comm) =
+        Allgather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), comm)
+    Allgather!(sendbuf::AbstractArray, recvbuf::AbstractInboundsArray, comm::Comm) =
+        Allgather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), comm)
+    Allgather(sendbuf::AbstractInboundsArray, comm::Comm) =
+        Allgather!(sendbuf, similar(sendbuf, Comm_size(comm) * length(sendbuf)), comm)
+    function Reduce(sendbuf::AbstractInboundsArray, op, root::Integer, comm::Comm)
+        if Comm_rank(comm) == root
+            Reduce!(sendbuf, similar(sendbuf), op, root, comm)
+        else
+            Reduce!(sendbuf, nothing, op, root, comm)
+        end
+    end
+    Allreduce(sendbuf::AbstractInboundsArray, op, comm::Comm) =
+        Allreduce!(sendbuf, similar(sendbuf), op, comm)
+    Scan(sendbuf::AbstractInboundsArray, op, comm::Comm) =
+        Scan!(sendbuf, similar(sendbuf), op, comm)
+    Exscan(sendbuf::AbstractInboundsArray, op, comm::Comm) =
+        Exscan!(sendbuf, similar(sendbuf), op, comm)
+    Neighbor_allgather!(sendbuf::Union{Ref,AbstractInboundsArray}, recvbuf::AbstractInboundsArray, graph_comm::Comm) =
+        Neighbor_allgather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), graph_comm)
+    Neighbor_allgather!(sendbuf::AbstractInboundsArray, recvbuf::AbstractArray, graph_comm::Comm) =
+        Neighbor_allgather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), graph_comm)
+    Neighbor_allgather!(sendbuf::AbstractArray, recvbuf::AbstractInboundsArray, graph_comm::Comm) =
+        Neighbor_allgather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), graph_comm)
+    Neighbor_allgatherv!(sendbuf::Union{Ref,AbstractInboundsArray}, recvbuf::AbstractInboundsArray, graph_comm::Comm) =
+        Neighbor_allgatherv!(sendbuf, VBuffer(recvbuf, length(sendbuf)), graph_comm)
+    Neighbor_allgatherv!(sendbuf::AbstractInboundsArray, recvbuf::AbstractArray, graph_comm::Comm) =
+        Neighbor_allgatherv!(sendbuf, VBuffer(recvbuf, length(sendbuf)), graph_comm)
+    Neighbor_allgatherv!(sendbuf::AbstractArray, recvbuf::AbstractInboundsArray, graph_comm::Comm) =
+        Neighbor_allgatherv!(sendbuf, VBuffer(recvbuf, length(sendbuf)), graph_comm)
+    function Win_attach!(win::Win, base::AbstractInboundsArray{T}) where T
+        # int MPI_Win_attach(MPI_Win win, void *base, MPI_Aint size)
+        API.MPI_Win_attach(win, base.a, sizeof(base))
+        push!(win.object, base.a)
+    end
+    function Win_detach!(win::Win, base::AbstractInboundsArray{T}) where T
+        # int MPI_Win_detach(MPI_Win win, const void *base)
+        API.MPI_Win_detach(win, base.a)
+        delete!(win.object, base.a)
+    end
+    Send(arr::AbstractInboundsArray, dest::Integer, tag::Integer, comm::Comm) =
+        Send(Buffer(arr), dest, tag, comm)
 end
 
 end

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -128,7 +128,7 @@ InboundsMatrix{T, TMatrix} = InboundsArray{T, 2, TMatrix} where {T, TMatrix}
 import Base: getindex, setindex!, size, IndexStyle, length, similar, axes, BroadcastStyle,
              copyto!, copy, resize!, unsafe_convert, strides, elsize, view, maybeview,
              reshape, isapprox, iterate, eachindex, broadcastable, vec, *, adjoint,
-             lastindex, isassigned
+             lastindex, isassigned, reverse!, reverse, push!, pop!
 
 @inline InboundsArray(A::InboundsArray) = A
 
@@ -290,6 +290,24 @@ end
 end
 @inline function *(A::InboundsArray{Tm, 2, TArrayA}, x::InboundsArray{Tx, Nx, TArrayx}) where {Tm, TArrayA, Tx, Nx, TArrayx}
     return InboundsArray(A.a * x.a)
+end
+
+@inline function reverse!(v::AbstractInboundsArray{T, 1} where T)
+    reverse!(v.a)
+    return v
+end
+
+@inline function reverse(v::InboundsVector)
+    return InboundsVector(reverse(v.a))
+end
+
+@inline function push!(v::AbstractInboundsArray{T, 1} where T, args...)
+    push!(v.a, args...)
+    return v
+end
+
+@inline function pop!(v::AbstractInboundsArray{T, 1} where T, args...)
+    return pop!(v.a, args...)
 end
 
 if !inherit_from_AbstractArray

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -204,6 +204,11 @@ end
 @inline function IndexStyle(::InboundsArray{T, N, TArray}) where {T, N, TArray}
     return IndexStyle(TArray)
 end
+@inline IndexStyle(A::AbstractInboundsArray, B::AbstractInboundsArray) = IndexStyle(IndexStyle(A), IndexStyle(B))
+@inline IndexStyle(A::AbstractInboundsArray, B::AbstractArray) = IndexStyle(IndexStyle(A), IndexStyle(B))
+@inline IndexStyle(A::AbstractArray, B::AbstractInboundsArray) = IndexStyle(IndexStyle(A), IndexStyle(B))
+@inline IndexStyle(A::AbstractInboundsArray, B...) = IndexStyle(IndexStyle(A), IndexStyle(B...))
+@inline IndexStyle(A::AbstractArray, B::AbstractInboundsArray, C...) = IndexStyle(IndexStyle(A), IndexStyle(B, IndexStyle(C...)))
 
 @inline function length(A::AbstractInboundsArray)
     return length(A.a)

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -125,11 +125,11 @@ Construct with one of:
 """
 InboundsMatrix{T, TMatrix} = InboundsArray{T, 2, TMatrix} where {T, TMatrix}
 
-import Base: getindex, setindex!, size, IndexStyle, length, similar, axes, BroadcastStyle,
-             copyto!, copy, resize!, unsafe_convert, strides, elsize, view, maybeview,
-             reshape, isapprox, iterate, eachindex, broadcastable, vec, *, adjoint,
-             lastindex, isassigned, reverse!, reverse, push!, pop!, sum, prod, maximum,
-             minimum, all, any, extrema
+import Base: getindex, setindex!, size, IndexStyle, length, ndims, similar, axes,
+             BroadcastStyle, copyto!, copy, resize!, unsafe_convert, strides, elsize,
+             view, maybeview, reshape, isapprox, iterate, eachindex, broadcastable, vec,
+             *, adjoint, lastindex, isassigned, reverse!, reverse, push!, pop!, sum, prod,
+             maximum, minimum, all, any, extrema
 
 @inline InboundsArray(A::InboundsArray) = A
 
@@ -206,6 +206,8 @@ end
 @inline function length(A::AbstractInboundsArray)
     return length(A.a)
 end
+
+@inline ndims(A::AbstractInboundsArray{T, N}) where {T, N} = N
 
 @inline function similar(A::InboundsArray)
     return InboundsArray(similar(A.a))

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -232,10 +232,10 @@ end
 
 # Define these so that a broadcast operations with an InboundsArray return an
 # InboundsArray - see https://docs.julialang.org/en/v1/manual/interfaces/#Selecting-an-appropriate-output-array
-struct InboundsArrayStyle{A<:AbstractInboundsArray} <: Broadcast.AbstractArrayStyle{Any} end
-BroadcastStyle(::Type{<:InboundsArray{T, N, TArray}}) where {T, N, TArray} = InboundsArrayStyle{InboundsArray{T, N, TArray}}()
+struct InboundsArrayStyle{T, N} <: Broadcast.AbstractArrayStyle{Any} end
+BroadcastStyle(::Type{<:AbstractInboundsArray{T, N}}) where {T, N} = InboundsArrayStyle{T, N}()
 
-@inline function similar(bc::Broadcast.Broadcasted{InboundsArrayStyle{InboundsArray{T, N, TArray}}}, ::Type{ElType}) where {T, N, TArray, ElType}
+@inline function similar(bc::Broadcast.Broadcasted{InboundsArrayStyle{T, N}}, ::Type{ElType}) where {T, N, ElType}
     # Scan the inputs for the InboundsArray:
     A = find_iba(bc)
     # Create the output as an InboundsArray
@@ -280,6 +280,10 @@ end
 
 @inline function view(a::AbstractInboundsArray, I::Vararg{Any,M}) where M
     return InboundsArray(view(a.a, I...))
+end
+
+@inline function maybeview(a::AbstractInboundsArray, I::Vararg{Any,M}) where M
+    return InboundsArray(maybeview(a.a, I...))
 end
 
 @inline function *(A::InboundsArray{TA, NA, TArrayA}, x::AbstractArray{Tx, Nx}) where {TA, NA, TArrayA, Tx, Nx}

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -128,10 +128,10 @@ InboundsMatrix{T, TMatrix} = InboundsArray{T, 2, TMatrix} where {T, TMatrix}
 import Base: getindex, setindex!, size, IndexStyle, length, ndims, similar, axes,
              BroadcastStyle, copyto!, copy, resize!, unsafe_convert, strides, elsize,
              view, maybeview, reshape, isapprox, iterate, eachindex, broadcastable, vec,
-             *, adjoint, lastindex, isassigned, reverse!, reverse, push!, pop!, sum, prod,
-             maximum, minimum, all, any, extrema, searchsorted, searchsortedfirst,
-             searchsortedlast, findfirst, findlast, findnext, findprev, findall, findmax,
-             findmin, findmax!, findmin!
+             *, adjoint, transpose, inv, lastindex, isassigned, reverse!, reverse, push!,
+             pop!, sum, prod, maximum, minimum, all, any, extrema, searchsorted,
+             searchsortedfirst, searchsortedlast, findfirst, findlast, findnext, findprev,
+             findall, findmax, findmin, findmax!, findmin!
 
 @inline InboundsArray(A::InboundsArray) = A
 
@@ -319,6 +319,10 @@ end
     return pop!(v.a, args...)
 end
 
+@inline adjoint(A::InboundsArray) = InboundsArray(adjoint(A.a))
+@inline transpose(A::InboundsArray) = InboundsArray(transpose(A.a))
+@inline inv(A::InboundsArray) = InboundsArray(inv(A.a))
+
 if !inherit_from_AbstractArray
     @inline function copy(A::InboundsArray)
         return InboundsArray(@inbounds copy(A.a))
@@ -331,7 +335,6 @@ if !inherit_from_AbstractArray
         return A
     end
     @inline vec(A::AbstractInboundsArray) = reshape(A, length(A))
-    @inline adjoint(A::InboundsArray) = InboundsArray(adjoint(A.a))
     @inline lastindex(A::AbstractInboundsArray, args...) = lastindex(A.a, args...)
     @inline isassigned(A::AbstractInboundsArray, args...) = isassigned(A.a, args...)
 

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -128,7 +128,8 @@ InboundsMatrix{T, TMatrix} = InboundsArray{T, 2, TMatrix} where {T, TMatrix}
 import Base: getindex, setindex!, size, IndexStyle, length, similar, axes, BroadcastStyle,
              copyto!, copy, resize!, unsafe_convert, strides, elsize, view, maybeview,
              reshape, isapprox, iterate, eachindex, broadcastable, vec, *, adjoint,
-             lastindex, isassigned, reverse!, reverse, push!, pop!
+             lastindex, isassigned, reverse!, reverse, push!, pop!, sum, prod, maximum,
+             minimum, all, any, extrema
 
 @inline InboundsArray(A::InboundsArray) = A
 
@@ -374,6 +375,14 @@ if !inherit_from_AbstractArray
     @inline function isapprox(x::AbstractInboundsArray, y::AbstractInboundsArray; kwargs...)
         return isapprox(x.a, y.a; kwargs...)
     end
+
+    @inline sum(A::AbstractInboundsArray, args...; kwargs...) = sum(A.a, args...; kwargs...)
+    @inline prod(A::AbstractInboundsArray, args...; kwargs...) = prod(A.a, args...; kwargs...)
+    @inline maximum(A::AbstractInboundsArray, args...; kwargs...) = maximum(A.a, args...; kwargs...)
+    @inline minimum(A::AbstractInboundsArray, args...; kwargs...) = minimum(A.a, args...; kwargs...)
+    @inline extrema(A::AbstractInboundsArray, args...; kwargs...) = extrema(A.a, args...; kwargs...)
+    @inline all(A::AbstractInboundsArray, args...; kwargs...) = all(A.a, args...; kwargs...)
+    @inline any(A::AbstractInboundsArray, args...; kwargs...) = any(A.a, args...; kwargs...)
 end
 
 include("LinearAlgebra_support.jl")

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -129,7 +129,9 @@ import Base: getindex, setindex!, size, IndexStyle, length, ndims, similar, axes
              BroadcastStyle, copyto!, copy, resize!, unsafe_convert, strides, elsize,
              view, maybeview, reshape, isapprox, iterate, eachindex, broadcastable, vec,
              *, adjoint, lastindex, isassigned, reverse!, reverse, push!, pop!, sum, prod,
-             maximum, minimum, all, any, extrema
+             maximum, minimum, all, any, extrema, searchsorted, searchsortedfirst,
+             searchsortedlast, findfirst, findlast, findnext, findprev, findall, findmax,
+             findmin, findmax!, findmin!
 
 @inline InboundsArray(A::InboundsArray) = A
 
@@ -385,6 +387,31 @@ if !inherit_from_AbstractArray
     @inline extrema(A::AbstractInboundsArray, args...; kwargs...) = extrema(A.a, args...; kwargs...)
     @inline all(A::AbstractInboundsArray, args...; kwargs...) = all(A.a, args...; kwargs...)
     @inline any(A::AbstractInboundsArray, args...; kwargs...) = any(A.a, args...; kwargs...)
+    @inline searchsorted(v::AbstractInboundsArray, x; kwargs...) = searchsorted(v.a, x; kwargs...)
+    @inline searchsortedfirst(A::AbstractInboundsArray, args...; kwargs...) = searchsortedfirst(A.a, args...; kwargs...)
+    @inline searchsortedlast(A::AbstractInboundsArray, args...; kwargs...) = searchsortedlast(A.a, args...; kwargs...)
+    @inline findfirst(A::AbstractInboundsArray) = findfirst(A.a)
+    @inline findfirst(p::Function, A::AbstractInboundsArray, args...; kwargs...) = findfirst(p, A.a, args...; kwargs...)
+    @inline findfirst(p::AbstractInboundsArray, A::AbstractInboundsArray, args...; kwargs...) = findfirst(p.a, A.a, args...; kwargs...)
+    @inline findfirst(p, A::AbstractInboundsArray, args...; kwargs...) = findfirst(p, A.a, args...; kwargs...)
+    @inline findlast(A::AbstractInboundsArray) = findlast(A.a)
+    @inline findlast(p::Function, A::AbstractInboundsArray, args...; kwargs...) = findlast(p, A.a, args...; kwargs...)
+    @inline findlast(p::AbstractInboundsArray, A::AbstractInboundsArray, args...; kwargs...) = findlast(p.a, A.a, args...; kwargs...)
+    @inline findlast(p, A::AbstractInboundsArray, args...; kwargs...) = findlast(p, A.a, args...; kwargs...)
+    @inline findnext(A::AbstractInboundsArray, i) = findnext(A.a, i)
+    @inline findnext(p::Function, A::AbstractInboundsArray, args...; kwargs...) = findnext(p, A.a, args...; kwargs...)
+    @inline findnext(p::AbstractInboundsArray, A::AbstractInboundsArray, args...; kwargs...) = findnext(p.a, A.a, args...; kwargs...)
+    @inline findnext(p, A::AbstractInboundsArray, args...; kwargs...) = findnext(p, A.a, args...; kwargs...)
+    @inline findprev(A::AbstractInboundsArray, i) = findprev(A.a, i)
+    @inline findprev(p::Function, A::AbstractInboundsArray, args...; kwargs...) = findprev(p, A.a, args...; kwargs...)
+    @inline findprev(p::AbstractInboundsArray, A::AbstractInboundsArray, args...; kwargs...) = findprev(p.a, A.a, args...; kwargs...)
+    @inline findprev(p, A::AbstractInboundsArray, args...; kwargs...) = findprev(p, A.a, args...; kwargs...)
+    @inline findall(A::AbstractInboundsArray) = findall(A.a)
+    @inline findall(p, A::AbstractInboundsArray, args...; kwargs...) = findall(p, A.a, args...; kwargs...)
+    @inline findmax(A::AbstractInboundsArray, args...; kwargs...) = findmax(A.a, args...; kwargs...)
+    @inline findmin(A::AbstractInboundsArray, args...; kwargs...) = findmin(A.a, args...; kwargs...)
+    @inline findmax!(rval, rind, A::AbstractInboundsArray, args...; kwargs...) = findmax!(rval, rind, A.a, args...; kwargs...)
+    @inline findmin!(rval, rind, A::AbstractInboundsArray, args...; kwargs...) = findmin!(rval, rind, A.a, args...; kwargs...)
 end
 
 include("LinearAlgebra_support.jl")

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -127,11 +127,11 @@ InboundsMatrix{T, TMatrix} = InboundsArray{T, 2, TMatrix} where {T, TMatrix}
 
 import Base: getindex, setindex!, size, IndexStyle, length, ndims, similar, axes,
              BroadcastStyle, copyto!, copy, resize!, unsafe_convert, strides, elsize,
-             view, maybeview, reshape, isapprox, iterate, eachindex, broadcastable, vec,
-             *, adjoint, transpose, inv, lastindex, isassigned, reverse!, reverse, push!,
-             pop!, sum, prod, maximum, minimum, all, any, extrema, searchsorted,
-             searchsortedfirst, searchsortedlast, findfirst, findlast, findnext, findprev,
-             findall, findmax, findmin, findmax!, findmin!
+             view, maybeview, reshape, selectdim, isapprox, iterate, eachindex,
+             broadcastable, vec, *, adjoint, transpose, inv, lastindex, isassigned,
+             reverse!, reverse, push!, pop!, sum, prod, maximum, minimum, all, any,
+             extrema, searchsorted, searchsortedfirst, searchsortedlast, findfirst,
+             findlast, findnext, findprev, findall, findmax, findmin, findmax!, findmin!
 
 @inline InboundsArray(A::InboundsArray) = A
 
@@ -274,6 +274,10 @@ end
 
 @inline function reshape(a::AbstractInboundsArray, dims::Int64...)
     return InboundsArray(reshape(a.a, dims...))
+end
+
+@inline function selectdim(a::AbstractInboundsArray, d::Integer, i)
+    return InboundsArray(selectdim(a.a, d, i))
 end
 
 @inline function unsafe_convert(pt::Type{Ptr{T}}, a::InboundsArrays.InboundsArray{T, N, TArray}) where {T, N, TArray}

--- a/src/LinearAlgebra_support.jl
+++ b/src/LinearAlgebra_support.jl
@@ -1,6 +1,7 @@
 # Functions from LinearAlgebra.jl need to hand the work back to the optimized
 # implementations that work on `Array`, instead of the generic ones for `AbstractArray`.
 
+import Base: \
 import LinearAlgebra: lu, lu!, ldiv!, ldiv, Factorization, mul!
 
 @inline function ldiv!(x::InboundsVector, Alu::Factorization, b::InboundsVector)
@@ -45,4 +46,19 @@ end
 @inline function mul!(C::InboundsVector, A::InboundsMatrix, B::InboundsVector, α::Number, β::Number)
     mul!(C.a, A.a, B.a, α, β)
     return C
+end
+
+if !inherit_from_AbstractArray
+    @inline function \(A::Factorization, x::InboundsArray)
+        return InboundsArray(A \ x.a)
+    end
+    @inline function \(A::AbstractArray, x::InboundsArray)
+        return InboundsArray(A \ x.a)
+    end
+    @inline function \(A::InboundsArray, x::AbstractArray)
+        return InboundsArray(A.a \ x)
+    end
+    @inline function \(A::InboundsArray, x::InboundsArray)
+        return InboundsArray(A.a \ x.a)
+    end
 end

--- a/src/SparseArrays_support.jl
+++ b/src/SparseArrays_support.jl
@@ -3,7 +3,7 @@
 export InboundsSparseMatrixCSC, InboundsSparseVector, InboundsSparseMatrixCSR
 
 import Base: convert, copy, *
-import LinearAlgebra: lu, lu!, mul!
+import LinearAlgebra: lu, lu!, mul!, Factorization
 import SparseArrays: AbstractSparseMatrix, AbstractSparseMatrixCSC, SparseMatrixCSC,
                      AbstractCompressedVector, SparseVector, sparse, getcolptr, rowvals,
                      nonzeros, nonzeroinds

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,6 +203,16 @@ function runtests()
 
             a .= [1.0 2.0; 3.0 4.0]
             @test sum(a) == 10.0
+            ia = inv(a)
+            @test ia isa InboundsMatrix{Float64}
+            @test isclose(ia, [4.0 -2.0; -3.0 1.0] ./ (-2.0))
+            ta = transpose(a)
+            @test ta isa InboundsMatrix{Float64}
+            @test isequal(ta, [1.0 3.0; 2.0 4.0])
+            ca = InboundsArray([(1.0 + 2.0im) (3.0 + 4.0im); (5.0 + 6.0im) (7.0 + 8.0im)])
+            aca = adjoint(ca)
+            @test aca isa InboundsMatrix{ComplexF64}
+            @test isequal(aca, [(1.0 - 2.0im) (5.0 - 6.0im); (3.0 - 4.0im) (7.0 - 8.0im)])
         end
 
         @testset "InboundsArray" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -284,9 +284,15 @@ function runtests()
             r = reshape(a, 4, 2)
             @test r isa InboundsArray
             @test size(r) == (4, 2)
+            @test isequal(r, [6.0 6.0; 10.0 10.0; 8.0 8.0; 12.0 12.0])
             v = vec(a)
             @test v isa InboundsVector
             @test size(v) == (8,)
+            @test isequal(v, [6.0, 10.0, 8.0, 12.0, 6.0, 10.0, 8.0, 12.0])
+            s = selectdim(a, 3, 1)
+            @test s isa InboundsArray
+            @test size(s) == (2, 2)
+            @test isequal(s, [6.0 8.0; 10.0 12.0])
 
             @test !isa(get_noninbounds(a), AbstractInboundsArray)
             @test !isa(get_noninbounds(zeros(3, 3, 3)), AbstractInboundsArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,25 @@ function runtests()
             @test !isa(get_noninbounds(zeros(3)), AbstractInboundsArray)
 
             @test a[1:3] isa InboundsVector{Float64, Vector{Float64}}
+
+            a .= [6.0, 8.0, 10.0, 12.0]
+            @test reverse(a) isa InboundsVector{Float64, Vector{Float64}}
+            @test isequal(reverse(a), [12.0, 10.0, 8.0, 6.0])
+            reverse!(a)
+            @test a isa InboundsVector{Float64, Vector{Float64}}
+            @test isequal(a, [12.0, 10.0, 8.0, 6.0])
+
+            a .= [6.0, 8.0, 10.0, 12.0]
+            b = push!(a, 14.0)
+            @test a isa InboundsVector{Float64, Vector{Float64}}
+            @test b isa InboundsVector{Float64, Vector{Float64}}
+            @test isequal(a, [6.0, 8.0, 10.0, 12.0, 14.0])
+            @test isequal(b, a)
+            b = pop!(a)
+            @test a isa InboundsVector{Float64, Vector{Float64}}
+            @test isequal(a, [6.0, 8.0, 10.0, 12.0])
+            @test b isa Float64
+            @test b == 14.0
         end
 
         @testset "InboundsMatrix" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,17 @@ function runtests()
             @test any(@view b[1:3]) === true
             @test any(b[1:0]) === false
             @test any(@view b[1:0]) === false
+            @test searchsorted(a, 2.0) == [2]
+            @test searchsortedfirst(a, 2.0) == 2
+            @test searchsortedlast(a, 2.0) == 2
+            @test findfirst(InboundsArray([false, true, false, true])) == 2
+            @test findfirst((x) -> x > 1.5, a) == 2
+            @test findlast(InboundsArray([false, true, false, true])) == 4
+            @test findlast((x) -> x > 1.5, a) == 4
+            @test findnext(InboundsArray([false, true, false, true]), 3) == 4
+            @test findnext((x) -> x > 1.5, a, 3) == 3
+            @test findprev(InboundsArray([false, true, false, true]), 3) == 2
+            @test findprev((x) -> x > 1.5, a, 3) == 3
         end
 
         @testset "InboundsMatrix" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,6 +195,11 @@ function runtests()
             @test c isa InboundsArray
             @test isequal(c, [8.0 10.0; 12.0 14.0;;; 8.0 10.0; 12.0 14.0])
 
+            c .= 0.0
+            @. c[:, 1, 1] = a[:, 1, 1] + 2
+            @test c isa InboundsArray
+            @test isequal(c, [8.0 0.0; 12.0 0.0;;; 0.0 0.0; 0.0 0.0])
+
             d = similar(a)
             @test d isa InboundsArray{Float64, 3, Array{Float64, 3}}
             @test size(d) == (2, 2, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ function runtests()
 
             @test size(a) == (4,)
             @test length(a) == 4
+            @test ndims(a) == 1
             @test a[2] == 2.0
             a[2] = 42.0
             @test a[2] == 42.0
@@ -137,6 +138,7 @@ function runtests()
 
             @test size(a) == (2, 2)
             @test length(a) == 4
+            @test ndims(a) == 2
             @test a[1, 2] == 2.0
             a[1, 2] = 42.0
             @test a[1, 2] == 42.0
@@ -198,6 +200,7 @@ function runtests()
 
             @test size(a) == (2, 2, 2)
             @test length(a) == 8
+            @test ndims(a) == 3
             @test a[1, 2, 1] == 2.0
             a[1, 2, 1] = 42.0
             @test a[1, 2, 1] == 42.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -570,6 +570,15 @@ function runtests()
                 a_reconstructed = backward_transform * a_fft
                 @test a_reconstructed isa InboundsVector
                 @test isclose(a_reconstructed, a)
+
+                b = InboundsArray(ones(8))
+                r2r = FFTW.plan_r2r!(b, FFTW.REDFT00)
+
+                @. b = cos(π * (0.0:7.0) / 7)
+                b_fft = r2r * copy(b)
+                @test b_fft isa InboundsVector
+                println("b_fft ", b_fft)
+                @test isclose(b_fft, [0.0, 7.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
             end
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -623,6 +623,11 @@ function runtests()
                 @test isequal(b, ones(3, 4, 5))
 
                 b .= 0.0
+                vb = MPI.VBuffer(b, InboundsVector([3 * 4 * 5]))
+                MPI.Allgatherv!(a, vb, MPI.COMM_WORLD)
+                @test isequal(b, ones(3, 4, 5))
+
+                b .= 0.0
                 MPI.Bcast!(a, 0, MPI.COMM_WORLD)
                 @test isequal(a, ones(3, 4, 5))
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,6 +97,38 @@ function runtests()
             @test isequal(a, [6.0, 8.0, 10.0, 12.0])
             @test b isa Float64
             @test b == 14.0
+
+            a .= [1.0, 2.0, 3.0, 4.0]
+            @test sum(a) == 10.0
+            @test sum(a[1:3]) == 6.0
+            @test sum(@view a[1:3]) == 6.0
+            @test sum(a[1:0]) == 0.0
+            @test sum(@view a[1:0]) == 0.0
+            @test prod(a) == 24.0
+            @test prod(a[1:3]) == 6.0
+            @test prod(@view a[1:3]) == 6.0
+            @test prod(a[1:0]) == 1.0
+            @test prod(@view a[1:0]) == 1.0
+            @test maximum(a) == 4.0
+            @test maximum(a[1:3]) == 3.0
+            @test maximum(@view a[1:3]) == 3.0
+            @test minimum(a) == 1.0
+            @test minimum(a[1:3]) == 1.0
+            @test minimum(@view a[1:3]) == 1.0
+            @test extrema(a) == (1.0, 4.0)
+            @test extrema(a[1:3]) == (1.0, 3.0)
+            @test extrema(@view a[1:3]) == (1.0, 3.0)
+            b = InboundsVector([true, true, true, false])
+            @test all(b) === false
+            @test all(b[1:3]) === true
+            @test all(@view b[1:3]) === true
+            @test all(b[1:0]) === true
+            @test all(@view b[1:0]) === true
+            @test any(b) === true
+            @test any(b[1:3]) === true
+            @test any(@view b[1:3]) === true
+            @test any(b[1:0]) === false
+            @test any(@view b[1:0]) === false
         end
 
         @testset "InboundsMatrix" begin
@@ -155,6 +187,9 @@ function runtests()
 
             @test a[1:1, :] isa InboundsMatrix{Float64, Matrix{Float64}}
             @test a[:, 1:1] isa InboundsMatrix{Float64, Matrix{Float64}}
+
+            a .= [1.0 2.0; 3.0 4.0]
+            @test sum(a) == 10.0
         end
 
         @testset "InboundsArray" begin
@@ -235,6 +270,9 @@ function runtests()
             @test a[1:1, :, :] isa InboundsArray{Float64, 3, Array{Float64, 3}}
             @test a[:, 1:1, :] isa InboundsArray{Float64, 3, Array{Float64, 3}}
             @test a[:, :, 1:1] isa InboundsArray{Float64, 3, Array{Float64, 3}}
+
+            a .= [1.0 2.0; 3.0 4.0;;; 1.0 2.0; 3.0 4.0]
+            @test sum(a) == 20.0
         end
 
         @testset "LinearAlgebra interface" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,6 +177,13 @@ function runtests()
             @test c isa InboundsMatrix
             @test isequal(c, [30.0 48.0; 70.0 96.0])
 
+            e = InboundsMatrix([1.0 2.0 3.0; 4.0 5.0 6.0])
+            f = InboundsVector([10.0, 20.0])
+            g = e .+ f
+            @test g isa InboundsMatrix{Float64, Matrix{Float64}}
+            @test size(g) == (2, 3)
+            @test isequal(g, [11.0 12.0 13.0; 24.0 25.0 26.0])
+
             d = similar(a)
             @test d isa InboundsMatrix{Float64, Matrix{Float64}}
             @test size(d) == (2, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,6 +190,11 @@ function runtests()
             @test c isa InboundsArray
             @test isequal(c, [8.0 10.0; 12.0 14.0;;; 8.0 10.0; 12.0 14.0])
 
+            c .= 0.0
+            @. c = a + 2
+            @test c isa InboundsArray
+            @test isequal(c, [8.0 10.0; 12.0 14.0;;; 8.0 10.0; 12.0 14.0])
+
             d = similar(a)
             @test d isa InboundsArray{Float64, 3, Array{Float64, 3}}
             @test size(d) == (2, 2, 2)


### PR DESCRIPTION
This should mean we (usually) get an error rather than silently getting poor performance from an `AbstractArray` implementation when there is a more-specialized, optimized implementation available.

Unfortunately means we have to copy quite a few things from the AbstractArray interface from base/abstractarray.jl, but hopefully they are generic enough that they should not change often.