### PR TITLE
Default is to be a subtype of AbstractArray

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        abstractarray: [false, true]
+        no-abstractarray: [false, true]
         julia_version: ['1.10', '1']
       fail-fast: false
     timeout-minutes: 20
@@ -32,8 +32,8 @@ jobs:
       # recompile anyway.
       #- uses: julia-actions/julia-buildpkg@v1
       - run: |
-          julia --project --check-bounds=yes -e 'using InboundsArrays; InboundsArrays.set_inherit_from_AbstractArray(true)'
-        if: matrix.abstractarray
+          julia --project --check-bounds=yes -e 'using InboundsArrays; InboundsArrays.set_inherit_from_AbstractArray(false)'
+        if: matrix.no-abstractarray
         shell: bash
       - uses: julia-actions/julia-runtest@v1
 
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        abstractarray: [false, true]
+        no-abstractarray: [false, true]
         julia_version: ['1.10', '1']
       fail-fast: false
     timeout-minutes: 20
@@ -58,8 +58,8 @@ jobs:
         shell: bash
       - uses: julia-actions/julia-buildpkg@v1
       - run: |
-          julia --project -e 'using InboundsArrays; InboundsArrays.set_inherit_from_AbstractArray(true)'
-        if: matrix.abstractarray
+          julia --project -e 'using InboundsArrays; InboundsArrays.set_inherit_from_AbstractArray(false)'
+        if: matrix.no-abstractarray
         shell: bash
       # The following is copied and simplified from
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InboundsArrays"
 uuid = "fb0a3009-a0ba-48c7-b828-2efdeaae8962"
 authors = ["John Omotani <john.omotani@ukaea.uk>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -50,29 +50,35 @@ extra non-`InboundsArray` arguments. `InboundsArrays` provides many of these
 pass-through methods for commonly used packages/functions (if you need more,
 please open a PR - they are generally short to write!).
 
-In order to guarantee the best performance possible, by default
-`InboundsArrays` is defined so that there will be an error if an
-`InboundsArray` is passed to an unsupported function. This is achieved by not
-making `AbstractInboundsArray` a subtype of `AbstractArray`, so that a
-`MethodError()` will be throw if an `InboundsArray` is passed to a function
-that accepts an `AbstractArray`. In other words, we error rather than risking
-poor performance. If you know that all performance-critical functions are
-supported correctly, but there are some other functions that are not supported,
-or if you know that the `AbstractArray` interface provides optimal performance
-for any unsupported functions, it might be convenient for `InboundsArray` to be
-a subtype of `AbstractArray`. This can be achieved by calling
+Optionally error if using `AbstractArray` interface
+===================================================
+
+By default `InboundsArray` is a subtype of `AbstractArray` so will use the
+`AbstractArray` implementation if it exists and no pass-through method is
+defined.
+
+In order to guarantee the best performance possible, it is possible to define
+`InboundsArrays` so that there will be an error if an `InboundsArray` is passed
+to an unsupported function. This is achieved by not making
+`AbstractInboundsArray` a subtype of `AbstractArray`, so that a `MethodError()`
+will be throw if an `InboundsArray` is passed to a function that accepts an
+`AbstractArray`. In other words, we error rather than risking poor performance.
+If want to check that all performance-critical functions are supported
+correctly, you might want to do this - call
 ```julia
-InboundsArrays.set_inherit_from_AbstractArray(true)
+InboundsArrays.set_inherit_from_AbstractArray(false)
 ```
 This setting will be saved in `LocalPreferences.toml` and so will persist. Call
-again with no argument (or `false`) to reset to the default. After changing the
+again with no argument (or `true`) to reset to the default. After changing the
 setting you must restart Julia and recompile any system images that include
 `InboundsArrays` in order for the change to take effect.
 
-If you use `set_inherit_from_AbstractArray = true`, you are responsible for
-ensuring that there are no significant slow-downs from using `InboundsArray`
-instead of the array type that you would otherwise have used! It is preferred
-to add support for whatever functions you need to `InboundsArrays.jl`.
+If you use `set_inherit_from_AbstractArray = false`, many functions that could
+'just work' using the `AbstractArray` interface will error. You are welcome to
+request support for these functions (or even better open a PR to add the
+support!), but this is likely to make for a less than ideal user experience,
+especially if `InboundsArray`s could be returned from your package to an
+interactive context, where users might then pass them into any function.
 
 Status and development
 ----------------------

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -35,7 +35,7 @@ export InboundsArray, InboundsVector, InboundsMatrix, AbstractInboundsArray,
 
 using Preferences
 
-const default_inherit_from_AbstractArray = false
+const default_inherit_from_AbstractArray = true
 const inherit_from_AbstractArray = @load_preference("inherit_from_AbstractArray", default_inherit_from_AbstractArray)
 
 """

--- a/src/InboundsArrays.jl
+++ b/src/InboundsArrays.jl
@@ -368,6 +368,10 @@ end
     return InboundsArray(@inbounds view(a.a, I...))
 end
 
+@inline function maybeview(a::AbstractInboundsArray, I::Vararg{Union{Number, Base.AbstractCartesianIndex},M}) where M
+    return InboundsArray(@inbounds maybeview(a.a, I...))
+end
+
 @inline function maybeview(a::AbstractInboundsArray, I::Vararg{Any,M}) where M
     return InboundsArray(@inbounds maybeview(a.a, I...))
 end


### PR DESCRIPTION
This is more convenient, especially for interactive use, even though there is a possibility of sub-optimal performance. Optimal performance can be verified by explicitly configuring `InboundsArrays` to not make `InboundsArray` a subtype of `AbstractArray`.